### PR TITLE
Fix whitespace input

### DIFF
--- a/app/Livewire/KatalogSampah.php
+++ b/app/Livewire/KatalogSampah.php
@@ -68,6 +68,7 @@ class KatalogSampah extends Component
     public function store()
     {
         $this->authorize('create', Sampah::class);
+        $this->trimInput();
         $this->validate();
         $this->validate([
             'imageUpload' => 'required|mimes:jpg,jpeg,png|max:4096',
@@ -86,6 +87,7 @@ class KatalogSampah extends Component
     public function update()
     {
         $this->authorize('update', $this->sampahToEdit);
+        $this->trimInput();
         $this->validate();
         $this->validate([
             'imageUpload' => 'nullable|sometimes|mimes:jpg,jpeg,png|max:4096',
@@ -139,6 +141,11 @@ class KatalogSampah extends Component
             'nama' => '',
             'harga_per_kg' => '',
         ];
+    }
+
+    public function trimInput()
+    {
+        $this->dataInput['nama'] = str(trim($this->dataInput['nama']))->squish()->toString();
     }
 
     public function sortBy($field)

--- a/app/Livewire/UserProfileSettings.php
+++ b/app/Livewire/UserProfileSettings.php
@@ -64,6 +64,7 @@ class UserProfileSettings extends Component
 
     public function updateAdmin()
     {
+        $this->trimInput();
         $validated = $this->validate();
         $user = Auth::user();
 
@@ -92,6 +93,7 @@ class UserProfileSettings extends Component
 
     public function updateNasabah()
     {
+        $this->trimInput();
         $validated = $this->validate();
 
         $validatedProfile = $this->validate([
@@ -123,6 +125,14 @@ class UserProfileSettings extends Component
         } catch (\Exception $e) {
             Toaster::error('Gagal memperbarui informasi profil Anda.');
         }
+    }
+
+    public function trimInput()
+    {
+        $this->nama_depan = str(trim($this->nama_depan))->squish()->toString();
+        $this->nama_belakang = str(trim($this->nama_belakang))->squish()->toString();
+        $this->email = str(trim($this->email))->squish()->toString();
+        $this->alamat = str(trim($this->alamat))->squish()->toString();
     }
 
     public function deleteAvatar()


### PR DESCRIPTION
This pull request introduces a `trimInput` method in multiple Livewire components to ensure user input is sanitized by trimming whitespace and squishing strings before validation. The changes improve data consistency and prevent unnecessary whitespace in user inputs.

### Input sanitization improvements:

* `app/Livewire/KatalogSampah.php`:
  - Added a `trimInput` method to sanitize the `nama` field by trimming and squishing whitespace. This method is now invoked in the `store` and `update` methods to ensure input consistency. [[1]](diffhunk://#diff-66bf05df98062b642d2842f4fb4d3ccc08fb10f45c1c4afde2ec576a237463e9R71) [[2]](diffhunk://#diff-66bf05df98062b642d2842f4fb4d3ccc08fb10f45c1c4afde2ec576a237463e9R90) [[3]](diffhunk://#diff-66bf05df98062b642d2842f4fb4d3ccc08fb10f45c1c4afde2ec576a237463e9R146-R150)

* `app/Livewire/UserProfileSettings.php`:
  - Added a `trimInput` method to sanitize multiple fields (`nama_depan`, `nama_belakang`, `email`, `alamat`) by trimming and squishing whitespace. This method is now invoked in the `updateAdmin` and `updateNasabah` methods. [[1]](diffhunk://#diff-2d32935385afcacad3d7ee7eb78b8098dbb09d683dc9b0543dce400b27432e71R67) [[2]](diffhunk://#diff-2d32935385afcacad3d7ee7eb78b8098dbb09d683dc9b0543dce400b27432e71R96) [[3]](diffhunk://#diff-2d32935385afcacad3d7ee7eb78b8098dbb09d683dc9b0543dce400b27432e71R130-R137)